### PR TITLE
github-ci: Use container for Ubuntu 18.04 build - v2

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -263,6 +263,7 @@ jobs:
   ubuntu-18-04:
     name: Ubuntu 18.04 (Cocci)
     runs-on: ubuntu-18.04
+    container: ubuntu:18.04
     steps:
 
       # Cache Rust stuff.
@@ -274,13 +275,15 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt update
-          sudo apt -y install \
+          apt update
+          apt -y install \
                 libpcre3 \
                 libpcre3-dev \
                 build-essential \
                 autoconf \
                 automake \
+                git \
+                jq \
                 libtool \
                 libpcap-dev \
                 libnet1-dev \
@@ -298,15 +301,18 @@ jobs:
                 libevent-dev \
                 libevent-pthreads-2.1.6 \
                 libjansson-dev \
+                libpython2.7 \
                 make \
                 parallel \
+                python3-yaml \
+                rustc \
                 software-properties-common \
                 zlib1g \
                 zlib1g-dev
       - name: Install Coccinelle
         run: |
-          sudo add-apt-repository -y ppa:npalix/coccinelle
-          sudo apt -y install coccinelle
+          add-apt-repository -y ppa:npalix/coccinelle
+          apt -y install coccinelle
       - uses: actions/checkout@v1
       - run: git clone https://github.com/OISF/libhtp -b 0.5.x
       - run: ./autogen.sh
@@ -318,7 +324,7 @@ jobs:
       - name: Fetching suricata-verify
         run: git clone https://github.com/OISF/suricata-verify.git
       - name: Running suricata-verify
-        run: ./suricata-verify/run.py
+        run: python3 ./suricata-verify/run.py
 
   # An Ubuntu 16.04 build using the tarball generated in the CentOS 8
   # build above.

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-    AC_INIT([suricata],[5.0.1])
+    AC_INIT([suricata],[5.0.2-dev])
     m4_ifndef([AM_SILENT_RULES], [m4_define([AM_SILENT_RULES],[])])AM_SILENT_RULES([yes])
     AC_CONFIG_HEADERS([config.h])
     AC_CONFIG_SRCDIR([src/suricata.c])


### PR DESCRIPTION
Use an Ubuntu 18.04 container for the 18.04 build even though
the host OS is 18.04. This gives us a consistent base for this
test rather than what GitHub is giving this as the host
OS for GitHub actions.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
N/A