### PR TITLE
github-ci: add sccache to per-commit check

### DIFF
--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -25,6 +25,7 @@ jobs:
                 autoconf \
                 automake \
                 ccache \
+                curl \
                 git \
                 jq \
                 libtool \
@@ -55,10 +56,18 @@ jobs:
                 zlib1g \
                 zlib1g-dev
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - name: Installing sccache
+        run: |
+          (cd /tmp && curl -OL https://github.com/mozilla/sccache/releases/download/0.2.13/sccache-0.2.13-x86_64-unknown-linux-musl.tar.gz)
+          mkdir -p "$HOME/.cargo/bin"
+          (cd "$HOME/.cargo/bin" && tar xvf /tmp/sccache-0.2.13-x86_64-unknown-linux-musl.tar.gz --strip-components=1 --wildcards '*/sccache')
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
       - run: echo "/usr/lib/ccache" >> $GITHUB_PATH
       - name: Install cbindgen
-        run: cargo install cbindgen
-      - run: echo $PATH
+        run: |
+          cd $HOME/.cargo/bin
+          curl -OL https://github.com/eqrion/cbindgen/releases/download/v0.15.0/cbindgen
+          chmod 755 cbindgen
       - uses: actions/checkout@v1
       - run: git fetch
       - run: git clone https://github.com/OISF/libhtp -b 0.5.x
@@ -77,6 +86,7 @@ jobs:
               fi
               make -ik distclean > /dev/null
           done
+      - run: sccache -s
       - uses: actions/upload-artifact@v2-preview
         name: Uploading build log
         if: always()


### PR DESCRIPTION
Also use the pre-build cbindgen binary.
Hopefully speeds up the build process.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [ ] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [ ] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
-
-
-

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
