### PR TITLE
filestore: fix global counter init in unix socket mode

### DIFF
--- a/src/output-filestore.c
+++ b/src/output-filestore.c
@@ -527,9 +527,6 @@ static OutputInitResult OutputFilestoreLogInitCtx(ConfNode *conf)
         }
     }
 
-    StatsRegisterGlobalCounter("file_store.open_files",
-            OutputFilestoreOpenFilesCounter);
-
     result.ctx = output_ctx;
     result.ok = true;
     SCReturnCT(result, "OutputInitResult");
@@ -547,5 +544,12 @@ void OutputFilestoreRegister(void)
 
     SC_ATOMIC_INIT(filestore_open_file_cnt);
     SC_ATOMIC_SET(filestore_open_file_cnt, 0);
+#endif
+}
+
+void OutputFilestoreRegisterGlobalCounters(void)
+{
+#ifdef HAVE_NSS
+    StatsRegisterGlobalCounter("file_store.open_files", OutputFilestoreOpenFilesCounter);
 #endif
 }

--- a/src/output-filestore.h
+++ b/src/output-filestore.h
@@ -20,5 +20,6 @@
 
 void OutputFilestoreRegister(void);
 void OutputFilestoreInitConfig(void);
+void OutputFilestoreRegisterGlobalCounters(void);
 
 #endif /* __OUTPUT_FILESTORE_H__ */

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -129,6 +129,8 @@
 #include "app-layer-smb.h"
 #include "app-layer-dcerpc.h"
 
+#include "output-filestore.h"
+
 #include "util-ebpf.h"
 #include "util-radix-tree.h"
 #include "util-host-os-info.h"
@@ -2026,6 +2028,7 @@ void PreRunInit(const int runmode)
     StreamTcpInitConfig(STREAM_VERBOSE);
     AppLayerParserPostStreamSetup();
     AppLayerRegisterGlobalCounters();
+    OutputFilestoreRegisterGlobalCounters();
 }
 
 /* tasks we need to run before packets start flowing,


### PR DESCRIPTION
Move initialization of filestore global counter to PreRunInit,
so they get registered during program initialization, or as
required in unix-socket mode, initialized for each file run.

Fixes Redmine issue:
https://redmine.openinfosecfoundation.org/issues/4216

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [ ] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [ ] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
-
-
-

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
