### PR TITLE
scratch sccache test

### DIFF
--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -69,7 +69,7 @@ jobs:
               git checkout $rev
               echo "Building rev ${rev}" | tee -a build_log.txt
               ./autogen.sh >> build_log.txt 2>&1
-              ./configure --enable-unittests >> build_log.txt 2>&1
+              CC="sccache gcc" ./configure --enable-unittests >> build_log.txt 2>&1
               if ! make -j2 >> build_log.txt 2>&1; then
                   echo "::error ::Failed to build rev ${rev}"
                   tail -n 50 build_log.txt

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -960,23 +960,25 @@ static AppLayerResult HTPHandleResponseData(Flow *f, void *htp_state,
                 if (tx != NULL && tx->response_status_number == 101) {
                     htp_header_t *h =
                             (htp_header_t *)htp_table_get_c(tx->response_headers, "Upgrade");
-                    if (h != NULL) {
-                        if (bstr_cmp_c(h->value, "h2c") == 0) {
-                            uint16_t dp = 0;
-                            if (tx->request_port_number != -1) {
-                                dp = (uint16_t)tx->request_port_number;
-                            }
-                            consumed = htp_connp_res_data_consumed(hstate->connp);
-                            AppLayerRequestProtocolChange(hstate->f, dp, ALPROTO_HTTP2);
-                            // During HTTP2 upgrade, we may consume the HTTP1 part of the data
-                            // and we need to parser the remaining part with HTTP2
-                            if (consumed > 0 && consumed < input_len) {
-                                SCReturnStruct(
-                                        APP_LAYER_INCOMPLETE(consumed, input_len - consumed));
-                            }
-                            SCReturnStruct(APP_LAYER_OK);
-                        }
+                    if (h == NULL) {
+                        break;
                     }
+                    if (bstr_cmp_c(h->value, "h2c") != 0) {
+                        break;
+                    }
+                    uint16_t dp = 0;
+                    if (tx->request_port_number != -1) {
+                        dp = (uint16_t)tx->request_port_number;
+                    }
+                    consumed = htp_connp_res_data_consumed(hstate->connp);
+                    AppLayerRequestProtocolChange(hstate->f, dp, ALPROTO_HTTP2);
+                    // During HTTP2 upgrade, we may consume the HTTP1 part of the data
+                    // and we need to parser the remaining part with HTTP2
+                    if (consumed > 0 && consumed < input_len) {
+                        SCReturnStruct(
+                                APP_LAYER_INCOMPLETE(consumed, input_len - consumed));
+                    }
+                    SCReturnStruct(APP_LAYER_OK);
                 }
                 break;
             default:

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -325,6 +325,7 @@ static int TCPProtoDetect(ThreadVars *tv,
 #endif
 
     bool reverse_flow = false;
+    DEBUG_VALIDATE_BUG_ON(data == NULL && data_len > 0);
     PACKET_PROFILING_APP_PD_START(app_tctx);
     *alproto = AppLayerProtoDetectGetProto(app_tctx->alpd_tctx,
             f, data, data_len,

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -205,11 +205,9 @@ static void TCPProtoDetectCheckBailConditions(ThreadVars *tv,
         return;
     }
 
-    const uint64_t size_ts = STREAM_HAS_SEEN_DATA(&ssn->client) ?
-        STREAM_RIGHT_EDGE(&ssn->client) : 0;
-    const uint64_t size_tc = STREAM_HAS_SEEN_DATA(&ssn->server) ?
-        STREAM_RIGHT_EDGE(&ssn->server) : 0;
-    SCLogDebug("size_ts %"PRIu64", size_tc %"PRIu64, size_ts, size_tc);
+    const uint32_t size_ts = StreamDataAvailableForProtoDetect(&ssn->client);
+    const uint32_t size_tc = StreamDataAvailableForProtoDetect(&ssn->server);
+    SCLogDebug("size_ts %" PRIu32 ", size_tc %" PRIu32, size_ts, size_tc);
 
     DEBUG_VALIDATE_BUG_ON(size_ts > 1000000UL);
     DEBUG_VALIDATE_BUG_ON(size_tc > 1000000UL);

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -587,6 +587,20 @@ static uint32_t StreamTcpReassembleCheckDepth(TcpSession *ssn, TcpStream *stream
     SCReturnUInt(0);
 }
 
+uint32_t StreamDataAvailableForProtoDetect(TcpStream *stream)
+{
+    if (RB_EMPTY(&stream->sb.sbb_tree)) {
+        if (stream->sb.stream_offset != 0)
+            return 0;
+
+        return stream->sb.buf_offset;
+    } else {
+        DEBUG_VALIDATE_BUG_ON(stream->sb.head == NULL);
+        DEBUG_VALIDATE_BUG_ON(stream->sb.sbb_size == 0);
+        return stream->sb.sbb_size;
+    }
+}
+
 /**
  *  \brief Insert a packets TCP data into the stream reassembly engine.
  *

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -1150,7 +1150,9 @@ static int ReassembleUpdateAppLayer (ThreadVars *tv,
 
         } else if (flags & STREAM_DEPTH) {
             // we're just called once with this flag, so make sure we pass it on
-
+            if (mydata == NULL && mydata_len > 0) {
+                mydata_len = 0;
+            }
         } else if (mydata == NULL || (mydata_len == 0 && ((flags & STREAM_EOF) == 0))) {
             /* Possibly a gap, but no new data. */
             if ((p->flags & PKT_PSEUDO_STREAM_END) == 0 || ssn->state < TCP_CLOSED)
@@ -1161,6 +1163,7 @@ static int ReassembleUpdateAppLayer (ThreadVars *tv,
             SCLogDebug("%"PRIu64" got %p/%u", p->pcap_cnt, mydata, mydata_len);
             break;
         }
+        DEBUG_VALIDATE_BUG_ON(mydata == NULL && mydata_len > 0);
 
         SCLogDebug("stream %p data in buffer %p of len %u and offset %"PRIu64,
                 *stream, &(*stream)->sb, mydata_len, app_progress);

--- a/src/stream-tcp-reassemble.h
+++ b/src/stream-tcp-reassemble.h
@@ -140,5 +140,7 @@ static inline bool STREAM_LASTACK_GT_BASESEQ(const TcpStream *stream)
     return false;
 }
 
+uint32_t StreamDataAvailableForProtoDetect(TcpStream *stream);
+
 #endif /* __STREAM_TCP_REASSEMBLE_H__ */
 

--- a/src/threadvars.h
+++ b/src/threadvars.h
@@ -132,6 +132,7 @@ typedef struct ThreadVars_ {
     SCCtrlCondT *ctrl_cond;
 
     struct FlowQueue_ *flow_queue;
+    bool break_loop;
 
 } ThreadVars;
 

--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -668,6 +668,9 @@ void TmSlotSetFuncAppend(ThreadVars *tv, TmModule *tm, const void *data)
         slot->SlotFunc = tm->Func;
     } else if (tm->PktAcqLoop) {
         slot->PktAcqLoop = tm->PktAcqLoop;
+        if (tm->PktAcqBreakLoop) {
+            tv->break_loop = true;
+        }
     } else if (tm->Management) {
         slot->Management = tm->Management;
     }
@@ -2280,6 +2283,23 @@ uint16_t TmThreadsGetWorkerThreadMax()
     return thread_max;
 }
 
+static inline void ThreadBreakLoop(ThreadVars *tv)
+{
+    if ((tv->tmm_flags & TM_FLAG_RECEIVE_TM) == 0) {
+        return;
+    }
+    /* find the correct slot */
+    TmSlot *s = tv->tm_slots;
+    TmModule *tm = TmModuleGetById(s->tm_id);
+    if (tm->flags & TM_FLAG_RECEIVE_TM) {
+        /* if the method supports it, BreakLoop. Otherwise we rely on
+         * the capture method's recv timeout */
+        if (tm->PktAcqLoop && tm->PktAcqBreakLoop) {
+            tm->PktAcqBreakLoop(tv, SC_ATOMIC_GET(s->slot_data));
+        }
+    }
+}
+
 /**
  *  \retval r 1 if packet was accepted, 0 otherwise
  *  \note if packet was not accepted, it's still the responsibility
@@ -2308,6 +2328,8 @@ int TmThreadsInjectPacketsById(Packet **packets, const int id)
     /* wake up listening thread(s) if necessary */
     if (tv->inq != NULL) {
         SCCondSignal(&tv->inq->pq->cond_q);
+    } else if (tv->break_loop) {
+        ThreadBreakLoop(tv);
     }
     return 1;
 }
@@ -2330,5 +2352,7 @@ void TmThreadsInjectFlowById(Flow *f, const int id)
     /* wake up listening thread(s) if necessary */
     if (tv->inq != NULL) {
         SCCondSignal(&tv->inq->pq->cond_q);
+    } else if (tv->break_loop) {
+        ThreadBreakLoop(tv);
     }
 }

--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -1339,17 +1339,16 @@ again:
             if (!fq_done) {
                 SCMutexUnlock(&tv_root_lock);
 
-                    Packet *p = PacketGetFromAlloc();
-                    if (p != NULL) {
-                        //SCLogNotice("flush packet created");
-                        p->flags |= PKT_PSEUDO_STREAM_END;
-                        PKT_SET_SRC(p, PKT_SRC_DETECT_RELOAD_FLUSH);
-                        PacketQueue *q = tv->stream_pq;
-                        SCMutexLock(&q->mutex_q);
-                        PacketEnqueue(q, p);
-                        SCCondSignal(&q->cond_q);
-                        SCMutexUnlock(&q->mutex_q);
-                    }
+                Packet *p = PacketGetFromAlloc();
+                if (p != NULL) {
+                    p->flags |= PKT_PSEUDO_STREAM_END;
+                    PKT_SET_SRC(p, PKT_SRC_DETECT_RELOAD_FLUSH);
+                    PacketQueue *q = tv->stream_pq;
+                    SCMutexLock(&q->mutex_q);
+                    PacketEnqueue(q, p);
+                    SCCondSignal(&q->cond_q);
+                    SCMutexUnlock(&q->mutex_q);
+                }
 
                 /* don't sleep while holding a lock */
                 SleepMsec(1);
@@ -1430,7 +1429,6 @@ again:
 
                     Packet *p = PacketGetFromAlloc();
                     if (p != NULL) {
-                        //SCLogNotice("flush packet created");
                         p->flags |= PKT_PSEUDO_STREAM_END;
                         PKT_SET_SRC(p, PKT_SRC_DETECT_RELOAD_FLUSH);
                         PacketQueue *q = tv->stream_pq;

--- a/src/tm-threads.h
+++ b/src/tm-threads.h
@@ -159,7 +159,7 @@ static inline void TmThreadsSlotProcessPktFail(ThreadVars *tv, TmSlot *s, Packet
  *         manager.
  *  \param s pipeline to run on these packets.
  */
-static inline void TmThreadsHandleInjectedPackets(ThreadVars *tv)
+static inline bool TmThreadsHandleInjectedPackets(ThreadVars *tv)
 {
     PacketQueue *pq = tv->stream_pq_local;
     if (pq && pq->len > 0) {
@@ -176,6 +176,9 @@ static inline void TmThreadsHandleInjectedPackets(ThreadVars *tv)
             }
             tv->tmqh_out(tv, extra_p);
         }
+        return true;
+    } else {
+        return false;
     }
 }
 
@@ -221,18 +224,34 @@ static inline void TmThreadsCaptureInjectPacket(ThreadVars *tv, Packet *p)
     }
 }
 
+/** \brief handle capture timeout
+ *  When a capture method times out we check for house keeping
+ *  tasks in the capture thread.
+ *
+ *  \param p packet. Capture method may have taken a packet from
+ *           the pool prior to the timing out call. We will then
+ *           use that packet. Otherwise we can get our own.
+ */
 static inline void TmThreadsCaptureHandleTimeout(ThreadVars *tv, Packet *p)
 {
     if (TmThreadsCheckFlag(tv, THV_CAPTURE_INJECT_PKT)) {
-        TmThreadsCaptureInjectPacket(tv, p);
-    } else {
-        TmThreadsHandleInjectedPackets(tv);
+        TmThreadsCaptureInjectPacket(tv, p); /* consumes 'p' */
+        return;
 
-        /* packet could have been passed to us that we won't use
-         * return it to the pool. */
-        if (p != NULL)
-            tv->tmqh_out(tv, p);
+    } else {
+        if (TmThreadsHandleInjectedPackets(tv) == false) {
+            /* see if we have to do some house keeping */
+            if (tv->flow_queue && SC_ATOMIC_GET(tv->flow_queue->non_empty) == true) {
+                TmThreadsCaptureInjectPacket(tv, p); /* consumes 'p' */
+                return;
+            }
+        }
     }
+
+    /* packet could have been passed to us that we won't use
+     * return it to the pool. */
+    if (p != NULL)
+        tv->tmqh_out(tv, p);
 }
 
 void TmThreadsListThreads(void);

--- a/src/util-streaming-buffer.c
+++ b/src/util-streaming-buffer.c
@@ -194,6 +194,7 @@ static void SBBInit(StreamingBuffer *sb,
     sbb2->len = data_len;
 
     sb->head = sbb;
+    sb->sbb_size = sbb->len + sbb2->len;
     SBB_RB_INSERT(&sb->sbb_tree, sbb);
     SBB_RB_INSERT(&sb->sbb_tree, sbb2);
 
@@ -221,6 +222,7 @@ static void SBBInitLeadingGap(StreamingBuffer *sb,
     sbb->len = data_len;
 
     sb->head = sbb;
+    sb->sbb_size = sbb->len;
     SBB_RB_INSERT(&sb->sbb_tree, sbb);
 
     SCLogDebug("sbb %"PRIu64", len %u",
@@ -255,6 +257,7 @@ static inline void ConsolidateFwd(StreamingBuffer *sb,
             tr: [       ]
         */
         if (sa->offset >= tr->offset && sa_re <= tr_re) {
+            sb->sbb_size -= sa->len;
             sa->len = tr->len;
             sa->offset = tr->offset;
             sa_re = sa->offset + sa->len;
@@ -272,6 +275,7 @@ static inline void ConsolidateFwd(StreamingBuffer *sb,
         } else if (sa->offset <= tr->offset && sa_re >= tr_re) {
             SCLogDebug("-> (fwd) tr %p %"PRIu64"/%u REMOVED ECLIPSED", tr, tr->offset, tr->len);
             SBB_RB_REMOVE(tree, tr);
+            sb->sbb_size -= tr->len;
             FREE(sb->cfg, tr, sizeof(StreamingBufferBlock));
         /*
             sa: [         ]
@@ -282,11 +286,13 @@ static inline void ConsolidateFwd(StreamingBuffer *sb,
         } else if (sa->offset < tr->offset && // starts before
                    sa_re >= tr->offset && sa_re < tr_re) // ends inside
         {
-            // merge
+            // merge. sb->sbb_size includes both so we need to adjust that too.
+            uint32_t combined_len = sa->len + tr->len;
             sa->len = tr_re - sa->offset;
             sa_re = sa->offset + sa->len;
             SCLogDebug("-> (fwd) tr %p %"PRIu64"/%u REMOVED MERGED", tr, tr->offset, tr->len);
             SBB_RB_REMOVE(tree, tr);
+            sb->sbb_size -= (combined_len - sa->len); // remove what we added twice
             FREE(sb->cfg, tr, sizeof(StreamingBufferBlock));
         }
     }
@@ -307,6 +313,7 @@ static inline void ConsolidateBackward(StreamingBuffer *sb,
             break; // entirely after
 
         if (sa->offset >= tr->offset && sa_re <= tr_re) {
+            sb->sbb_size -= sa->len; // sa entirely eclipsed so remove double accounting
             sa->len = tr->len;
             sa->offset = tr->offset;
             sa_re = sa->offset + sa->len;
@@ -328,6 +335,7 @@ static inline void ConsolidateBackward(StreamingBuffer *sb,
             if (sb->head == tr)
                 sb->head = sa;
             SBB_RB_REMOVE(tree, tr);
+            sb->sbb_size -= tr->len; // tr entirely eclipsed so remove double accounting
             FREE(sb->cfg, tr, sizeof(StreamingBufferBlock));
         /*
             sa:     [   ]
@@ -336,7 +344,8 @@ static inline void ConsolidateBackward(StreamingBuffer *sb,
             tr: [   ]
         */
         } else if (sa->offset > tr->offset && sa_re > tr_re && sa->offset <= tr_re) {
-            // merge
+            // merge. sb->sbb_size includes both so we need to adjust that too.
+            uint32_t combined_len = sa->len + tr->len;
             sa->len = sa_re - tr->offset;
             sa->offset = tr->offset;
             sa_re = sa->offset + sa->len;
@@ -344,6 +353,7 @@ static inline void ConsolidateBackward(StreamingBuffer *sb,
             if (sb->head == tr)
                 sb->head = sa;
             SBB_RB_REMOVE(tree, tr);
+            sb->sbb_size -= (combined_len - sa->len); // remove what we added twice
             FREE(sb->cfg, tr, sizeof(StreamingBufferBlock));
         }
     }
@@ -366,6 +376,7 @@ static int Insert(StreamingBuffer *sb, struct SBB *tree,
         FREE(sb->cfg, sbb, sizeof(StreamingBufferBlock));
         return 0;
     }
+    sb->sbb_size += len; // may adjust based on consolidation below
     if (SBB_RB_PREV(sbb) == NULL) {
         sb->head = sbb;
     } else {
@@ -389,6 +400,7 @@ static void SBBFree(StreamingBuffer *sb)
     StreamingBufferBlock *sbb = NULL, *safe = NULL;
     RB_FOREACH_SAFE(sbb, SBB, &sb->sbb_tree, safe) {
         SBB_RB_REMOVE(&sb->sbb_tree, sbb);
+        sb->sbb_size -= sbb->len;
         FREE(sb->cfg, sbb, sizeof(StreamingBufferBlock));
     }
     sb->head = NULL;
@@ -413,6 +425,7 @@ static void SBBPrune(StreamingBuffer *sb)
             if (sbb->len >= shrink_by) {
                 sbb->len -=  shrink_by;
                 sbb->offset += shrink_by;
+                sb->sbb_size -= shrink_by;
                 DEBUG_VALIDATE_BUG_ON(sbb->offset != sb->stream_offset);
             }
             sb->head = sbb;
@@ -422,6 +435,7 @@ static void SBBPrune(StreamingBuffer *sb)
         SBB_RB_REMOVE(&sb->sbb_tree, sbb);
         /* either we set it again for the next sbb, or there isn't any */
         sb->head = NULL;
+        sb->sbb_size -= sbb->len;
         SCLogDebug("sb %p removed %p %"PRIu64", %u", sb, sbb, sbb->offset, sbb->len);
         FREE(sb->cfg, sbb, sizeof(StreamingBufferBlock));
     }
@@ -941,6 +955,7 @@ static int StreamingBufferTest01(void)
     FAIL_IF(!StreamingBufferSegmentCompareRawData(sb,seg1,(const uint8_t *)"ABCDEFGH", 8));
     FAIL_IF(!StreamingBufferSegmentCompareRawData(sb,seg2,(const uint8_t *)"01234567", 8));
     Dump(sb);
+    FAIL_IF_NOT_NULL(sb->head);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment *seg3 = StreamingBufferAppendRaw(sb, (const uint8_t *)"QWERTY", 6);
@@ -952,6 +967,7 @@ static int StreamingBufferTest01(void)
     FAIL_IF(StreamingBufferSegmentIsBeforeWindow(sb,seg3));
     FAIL_IF(!StreamingBufferSegmentCompareRawData(sb,seg3,(const uint8_t *)"QWERTY", 6));
     Dump(sb);
+    FAIL_IF_NOT_NULL(sb->head);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment *seg4 = StreamingBufferAppendRaw(sb, (const uint8_t *)"KLM", 3);
@@ -964,6 +980,7 @@ static int StreamingBufferTest01(void)
     FAIL_IF(StreamingBufferSegmentIsBeforeWindow(sb,seg4));
     FAIL_IF(!StreamingBufferSegmentCompareRawData(sb,seg4,(const uint8_t *)"KLM", 3));
     Dump(sb);
+    FAIL_IF_NOT_NULL(sb->head);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment *seg5 = StreamingBufferAppendRaw(sb, (const uint8_t *)"!@#$%^&*()_+<>?/,.;:'[]{}-=", 27);
@@ -977,6 +994,7 @@ static int StreamingBufferTest01(void)
     FAIL_IF(StreamingBufferSegmentIsBeforeWindow(sb,seg5));
     FAIL_IF(!StreamingBufferSegmentCompareRawData(sb,seg5,(const uint8_t *)"!@#$%^&*()_+<>?/,.;:'[]{}-=", 27));
     Dump(sb);
+    FAIL_IF_NOT_NULL(sb->head);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment *seg6 = StreamingBufferAppendRaw(sb, (const uint8_t *)"UVWXYZ", 6);
@@ -991,6 +1009,7 @@ static int StreamingBufferTest01(void)
     FAIL_IF(StreamingBufferSegmentIsBeforeWindow(sb,seg6));
     FAIL_IF(!StreamingBufferSegmentCompareRawData(sb,seg6,(const uint8_t *)"UVWXYZ", 6));
     Dump(sb);
+    FAIL_IF_NOT_NULL(sb->head);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     SCFree(seg1);
@@ -1022,9 +1041,11 @@ static int StreamingBufferTest02(void)
     Dump(sb);
     DumpSegment(sb, &seg1);
     DumpSegment(sb, &seg2);
+    FAIL_IF_NOT_NULL(sb->head);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSlide(sb, 6);
+    FAIL_IF_NOT_NULL(sb->head);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment seg3;
@@ -1039,6 +1060,7 @@ static int StreamingBufferTest02(void)
     DumpSegment(sb, &seg1);
     DumpSegment(sb, &seg2);
     DumpSegment(sb, &seg3);
+    FAIL_IF_NOT_NULL(sb->head);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSlide(sb, 6);
@@ -1049,6 +1071,7 @@ static int StreamingBufferTest02(void)
     DumpSegment(sb, &seg1);
     DumpSegment(sb, &seg2);
     DumpSegment(sb, &seg3);
+    FAIL_IF_NOT_NULL(sb->head);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferFree(sb);
@@ -1074,6 +1097,8 @@ static int StreamingBufferTest03(void)
     Dump(sb);
     DumpSegment(sb, &seg1);
     DumpSegment(sb, &seg2);
+    FAIL_IF_NULL(sb->head);
+    FAIL_IF_NOT(sb->sbb_size == 16);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment seg3;
@@ -1088,6 +1113,8 @@ static int StreamingBufferTest03(void)
     DumpSegment(sb, &seg1);
     DumpSegment(sb, &seg2);
     DumpSegment(sb, &seg3);
+    FAIL_IF_NULL(sb->head);
+    FAIL_IF_NOT(sb->sbb_size == 22);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSlide(sb, 10);
@@ -1098,6 +1125,8 @@ static int StreamingBufferTest03(void)
     DumpSegment(sb, &seg1);
     DumpSegment(sb, &seg2);
     DumpSegment(sb, &seg3);
+    FAIL_IF_NULL(sb->head);
+    FAIL_IF_NOT(sb->sbb_size == 12);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferFree(sb);
@@ -1155,6 +1184,8 @@ static int StreamingBufferTest04(void)
     DumpSegment(sb, &seg1);
     DumpSegment(sb, &seg2);
     DumpSegment(sb, &seg3);
+    FAIL_IF_NULL(sb->head);
+    FAIL_IF_NOT(sb->sbb_size == 22);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     /* far ahead of curve: */
@@ -1179,6 +1210,8 @@ static int StreamingBufferTest04(void)
     DumpSegment(sb, &seg2);
     DumpSegment(sb, &seg3);
     DumpSegment(sb, &seg4);
+    FAIL_IF_NULL(sb->head);
+    FAIL_IF_NOT(sb->sbb_size == 25);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     FAIL_IF(!StreamingBufferSegmentCompareRawData(sb,&seg1,(const uint8_t *)"ABCDEFGH", 8));
@@ -1241,16 +1274,22 @@ static int StreamingBufferTest06(void)
     StreamingBufferSegment seg2;
     FAIL_IF(StreamingBufferInsertAt(sb, &seg2, (const uint8_t *)"C", 1, 2) != 0);
     Dump(sb);
+    FAIL_IF_NULL(sb->head);
+    FAIL_IF_NOT(sb->sbb_size == 2);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment seg3;
     FAIL_IF(StreamingBufferInsertAt(sb, &seg3, (const uint8_t *)"F", 1, 5) != 0);
     Dump(sb);
+    FAIL_IF_NULL(sb->head);
+    FAIL_IF_NOT(sb->sbb_size == 3);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment seg4;
     FAIL_IF(StreamingBufferInsertAt(sb, &seg4, (const uint8_t *)"H", 1, 7) != 0);
     Dump(sb);
+    FAIL_IF_NULL(sb->head);
+    FAIL_IF_NOT(sb->sbb_size == 4);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment seg5;
@@ -1261,6 +1300,8 @@ static int StreamingBufferTest06(void)
     FAIL_IF(sbb1->offset != 0);
     FAIL_IF(sbb1->len != 10);
     FAIL_IF(SBB_RB_NEXT(sbb1));
+    FAIL_IF_NULL(sb->head);
+    FAIL_IF_NOT(sb->sbb_size == 10);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment seg6;
@@ -1271,6 +1312,8 @@ static int StreamingBufferTest06(void)
     FAIL_IF(sbb1->offset != 0);
     FAIL_IF(sbb1->len != 10);
     FAIL_IF(SBB_RB_NEXT(sbb1));
+    FAIL_IF_NULL(sb->head);
+    FAIL_IF_NOT(sb->sbb_size == 10);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferFree(sb);
@@ -1289,16 +1332,22 @@ static int StreamingBufferTest07(void)
     StreamingBufferSegment seg2;
     FAIL_IF(StreamingBufferInsertAt(sb, &seg2, (const uint8_t *)"D", 1, 3) != 0);
     Dump(sb);
+    FAIL_IF_NULL(sb->head);
+    FAIL_IF_NOT(sb->sbb_size == 2);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment seg3;
     FAIL_IF(StreamingBufferInsertAt(sb, &seg3, (const uint8_t *)"F", 1, 5) != 0);
     Dump(sb);
+    FAIL_IF_NULL(sb->head);
+    FAIL_IF_NOT(sb->sbb_size == 3);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment seg4;
     FAIL_IF(StreamingBufferInsertAt(sb, &seg4, (const uint8_t *)"H", 1, 7) != 0);
     Dump(sb);
+    FAIL_IF_NULL(sb->head);
+    FAIL_IF_NOT(sb->sbb_size == 4);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment seg5;
@@ -1309,6 +1358,8 @@ static int StreamingBufferTest07(void)
     FAIL_IF(sbb1->offset != 0);
     FAIL_IF(sbb1->len != 10);
     FAIL_IF(SBB_RB_NEXT(sbb1));
+    FAIL_IF_NULL(sb->head);
+    FAIL_IF_NOT(sb->sbb_size == 10);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment seg6;
@@ -1319,6 +1370,8 @@ static int StreamingBufferTest07(void)
     FAIL_IF(sbb1->offset != 0);
     FAIL_IF(sbb1->len != 10);
     FAIL_IF(SBB_RB_NEXT(sbb1));
+    FAIL_IF_NULL(sb->head);
+    FAIL_IF_NOT(sb->sbb_size == 10);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferFree(sb);
@@ -1337,16 +1390,22 @@ static int StreamingBufferTest08(void)
     StreamingBufferSegment seg2;
     FAIL_IF(StreamingBufferInsertAt(sb, &seg2, (const uint8_t *)"D", 1, 3) != 0);
     Dump(sb);
+    FAIL_IF_NULL(sb->head);
+    FAIL_IF_NOT(sb->sbb_size == 2);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment seg3;
     FAIL_IF(StreamingBufferInsertAt(sb, &seg3, (const uint8_t *)"F", 1, 5) != 0);
     Dump(sb);
+    FAIL_IF_NULL(sb->head);
+    FAIL_IF_NOT(sb->sbb_size == 3);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment seg4;
     FAIL_IF(StreamingBufferInsertAt(sb, &seg4, (const uint8_t *)"H", 1, 7) != 0);
     Dump(sb);
+    FAIL_IF_NULL(sb->head);
+    FAIL_IF_NOT(sb->sbb_size == 4);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment seg5;
@@ -1357,6 +1416,8 @@ static int StreamingBufferTest08(void)
     FAIL_IF(sbb1->offset != 0);
     FAIL_IF(sbb1->len != 10);
     FAIL_IF(SBB_RB_NEXT(sbb1));
+    FAIL_IF_NULL(sb->head);
+    FAIL_IF_NOT(sb->sbb_size == 10);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment seg6;
@@ -1367,6 +1428,8 @@ static int StreamingBufferTest08(void)
     FAIL_IF(sbb1->offset != 0);
     FAIL_IF(sbb1->len != 20);
     FAIL_IF(SBB_RB_NEXT(sbb1));
+    FAIL_IF_NULL(sb->head);
+    FAIL_IF_NOT(sb->sbb_size == 20);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferFree(sb);
@@ -1385,16 +1448,22 @@ static int StreamingBufferTest09(void)
     StreamingBufferSegment seg2;
     FAIL_IF(StreamingBufferInsertAt(sb, &seg2, (const uint8_t *)"D", 1, 3) != 0);
     Dump(sb);
+    FAIL_IF_NULL(sb->head);
+    FAIL_IF_NOT(sb->sbb_size == 2);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment seg3;
     FAIL_IF(StreamingBufferInsertAt(sb, &seg3, (const uint8_t *)"H", 1, 7) != 0);
     Dump(sb);
+    FAIL_IF_NULL(sb->head);
+    FAIL_IF_NOT(sb->sbb_size == 3);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment seg4;
     FAIL_IF(StreamingBufferInsertAt(sb, &seg4, (const uint8_t *)"F", 1, 5) != 0);
     Dump(sb);
+    FAIL_IF_NULL(sb->head);
+    FAIL_IF_NOT(sb->sbb_size == 4);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment seg5;
@@ -1405,6 +1474,8 @@ static int StreamingBufferTest09(void)
     FAIL_IF(sbb1->offset != 0);
     FAIL_IF(sbb1->len != 10);
     FAIL_IF(SBB_RB_NEXT(sbb1));
+    FAIL_IF_NULL(sb->head);
+    FAIL_IF_NOT(sb->sbb_size == 10);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment seg6;
@@ -1415,6 +1486,8 @@ static int StreamingBufferTest09(void)
     FAIL_IF(sbb1->offset != 0);
     FAIL_IF(sbb1->len != 10);
     FAIL_IF(SBB_RB_NEXT(sbb1));
+    FAIL_IF_NULL(sb->head);
+    FAIL_IF_NOT(sb->sbb_size == 10);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferFree(sb);
@@ -1437,6 +1510,8 @@ static int StreamingBufferTest10(void)
     StreamingBufferSegment seg3;
     FAIL_IF(StreamingBufferInsertAt(sb, &seg3, (const uint8_t *)"H", 1, 7) != 0);
     Dump(sb);
+    FAIL_IF_NULL(sb->head);
+    FAIL_IF_NOT(sb->sbb_size == 3);
 
     StreamingBufferSegment seg4;
     FAIL_IF(StreamingBufferInsertAt(sb, &seg4, (const uint8_t *)"B", 1, 1) != 0);
@@ -1448,6 +1523,8 @@ static int StreamingBufferTest10(void)
     FAIL_IF(StreamingBufferInsertAt(sb, &seg6, (const uint8_t *)"G", 1, 6) != 0);
     Dump(sb);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
+    FAIL_IF_NULL(sb->head);
+    FAIL_IF_NOT(sb->sbb_size == 6);
 
     StreamingBufferSegment seg7;
     FAIL_IF(StreamingBufferInsertAt(sb, &seg7, (const uint8_t *)"ABCDEFGHIJ", 10, 0) != 0);
@@ -1457,6 +1534,8 @@ static int StreamingBufferTest10(void)
     FAIL_IF(sbb1->offset != 0);
     FAIL_IF(sbb1->len != 10);
     FAIL_IF(SBB_RB_NEXT(sbb1));
+    FAIL_IF_NULL(sb->head);
+    FAIL_IF_NOT(sb->sbb_size == 10);
 
     StreamingBufferSegment seg8;
     FAIL_IF(StreamingBufferInsertAt(sb, &seg8, (const uint8_t *)"abcdefghij", 10, 0) != 0);
@@ -1467,6 +1546,8 @@ static int StreamingBufferTest10(void)
     FAIL_IF(sbb1->offset != 0);
     FAIL_IF(sbb1->len != 10);
     FAIL_IF(SBB_RB_NEXT(sbb1));
+    FAIL_IF_NULL(sb->head);
+    FAIL_IF_NOT(sb->sbb_size == 10);
 
     StreamingBufferFree(sb);
     PASS;

--- a/src/util-streaming-buffer.h
+++ b/src/util-streaming-buffer.h
@@ -102,15 +102,26 @@ typedef struct StreamingBuffer_ {
 
     struct SBB sbb_tree;    /**< red black tree of Stream Buffer Blocks */
     StreamingBufferBlock *head; /**< head, should always be the same as RB_MIN */
+    uint32_t sbb_size;          /**< data size covered by sbbs */
 #ifdef DEBUG
     uint32_t buf_size_max;
 #endif
 } StreamingBuffer;
 
 #ifndef DEBUG
-#define STREAMING_BUFFER_INITIALIZER(cfg) { (cfg), 0, NULL, 0, 0, { NULL }, NULL, };
+#define STREAMING_BUFFER_INITIALIZER(cfg)                                                          \
+    {                                                                                              \
+        (cfg),                                                                                     \
+        0,                                                                                         \
+        NULL,                                                                                      \
+        0,                                                                                         \
+        0,                                                                                         \
+        { NULL },                                                                                  \
+        NULL,                                                                                      \
+        0,                                                                                         \
+    };
 #else
-#define STREAMING_BUFFER_INITIALIZER(cfg) { (cfg), 0, NULL, 0, 0, { NULL }, NULL, 0 };
+#define STREAMING_BUFFER_INITIALIZER(cfg) { (cfg), 0, NULL, 0, 0, { NULL }, NULL, 0, 0 };
 #endif
 
 typedef struct StreamingBufferSegment_ {


### PR DESCRIPTION
- github-ci: use sccache for gcc in commits workflow
- threading: minor cleanups
- flow: process evicted flows on low/no traffic
- threading: force break loop on flow inject
- flow: free spare pool more aggressively
- ipv6: simpler generic overlap condition
- streaming/buffer: account sbb data size
- app-layer/pd: only consider actual available data
- app-layer/pd: review bailout conditions
- protodetect: handle all gaps, even when depth is reached
- http2: flatten code style
- http2: do not try to upgrade if http2 is disabled in config
