### PR TITLE
github: better var handling in pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,12 +11,16 @@ Describe changes:
 -
 -
 
-#suricata-verify-pr:
-#suricata-verify-repo:
-#suricata-verify-branch:
-#suricata-update-pr:
-#suricata-update-repo:
-#suricata-update-branch:
-#libhtp-pr:
-#libhtp-repo:
-#libhtp-branch:
+To use a custom repo, branch or pull request for suricata-verify,
+suricata-update or libhtp, uncomment the relevant lines below and change the
+value.
+
+#suricata-verify-pr: 100
+#suricata-verify-repo: https://github.com/OISF/suricata-verify
+#suricata-verify-branch: master
+#suricata-update-pr: 100
+#suricata-update-repo: https://github.com/OISF/suricata-update
+#suricata-update-branch: master
+#libhtp-pr: 100
+#libhtp-repo: https://github.com/OISF/libhtp
+#libhtp-branch: 0.5.x

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -54,17 +54,17 @@ jobs:
           if test "${PR_HREF}"; then
               body=$(curl -s "${PR_HREF}" | jq -r .body | tr -d '\r')
 
-              libhtp_repo=$(echo "${body}" | awk '/^libhtp-repo/ { print $2 }')
-              libhtp_branch=$(echo "${body}" | awk '/^libhtp-branch/ { print $2 }')
-              libhtp_pr=$(echo "${body}" | awk '/^libhtp-pr/ { print $2 }')
+              libhtp_repo=$(echo "${body}" | awk -F ':' '/^libhtp-repo/ { gsub(/ /, ""); print $2 }')
+              libhtp_branch=$(echo "${body}" | awk -F ':' '/^libhtp-branch/ { gsub(/ /, ""); print $2 }')
+              libhtp_pr=$(echo "${body}" | awk -F ':' '/^libhtp-pr/ { gsub(/ /, ""); print $2 }')
 
-              su_repo=$(echo "${body}" | awk '/^suricata-update-repo/ { print $2 }')
-              su_branch=$(echo "${body}" | awk '/^suricata-update-branch/ { print $2 }')
-              su_pr=$(echo "${body}" | awk '/^suricata-update-pr/ { print $2 }')
+              su_repo=$(echo "${body}" | awk -F ':' '/^suricata-update-repo/ { gsub(/ /, ""); print $2 }')
+              su_branch=$(echo "${body}" | awk -F ':' '/^suricata-update-branch/ { gsub(/ /, ""); print $2 }')
+              su_pr=$(echo "${body}" | awk -F ':' '/^suricata-update-pr/ { gsub(/ /, ""); print $2 }')
 
-              sv_repo=$(echo "${body}" | awk '/^suricata-verify-repo/ { print $2 }')
-              sv_branch=$(echo "${body}" | awk '/^suricata-verify-branch/ { print $2 }')
-              sv_pr=$(echo "${body}" | awk '/^suricata-verify-pr/ { print $2 }')
+              sv_repo=$(echo "${body}" | awk -F ':' '/^suricata-verify-repo/ { gsub(/ /, ""); print $2 }')
+              sv_branch=$(echo "${body}" | awk -F ':' '/^suricata-verify-branch/ { gsub(/ /, ""); print $2 }')
+              sv_pr=$(echo "${body}" | awk -F ':' '/^suricata-verify-pr/ { gsub(/ /, ""); print $2 }')
           fi
           echo "libhtp_repo=${libhtp_repo:-${DEFAULT_LIBHTP_REPO}}" >> $GITHUB_ENV
           echo "libhtp_branch=${libhtp_branch:-${DEFAULT_LIBHTP_BRANCH}}" >> $GITHUB_ENV
@@ -79,8 +79,10 @@ jobs:
           echo "sv_pr=${sv_pr:-${DEFAULT_SV_PR}}" >> $GITHUB_ENV
       - name: Fetching libhtp
         run: |
+          echo "Using ${libhtp_repo} -b ${libhtp_branch}."
           git clone --depth 1 ${libhtp_repo} -b ${libhtp_branch} libhtp
           if [[ "${libhtp_pr}" != "" ]]; then
+              echo "Switching to pull request ${libhtp_pr}."
               cd libhtp
               git fetch origin pull/${libhtp_pr}/head:prep
               git checkout prep
@@ -89,8 +91,10 @@ jobs:
           tar zcf libhtp.tar.gz libhtp
       - name: Fetching suricata-update
         run: |
+          echo "Using ${su_repo} -b ${su_branch}."
           git clone --depth 1 ${su_repo} -b ${su_branch} suricata-update
           if [[ "${su_pr}" != "" ]]; then
+              echo "Switcing to pull request ${su_pr}."
               cd suricata-update
               git fetch origin pull/${su_pr}/head:prep
               git checkout prep
@@ -99,8 +103,10 @@ jobs:
           tar zcf suricata-update.tar.gz suricata-update
       - name: Fetching suricata-verify
         run: |
-          git clone ${sv_repo} -b ${sv_branch} suricata-verify
+          echo "Using ${sv_repo} -b ${sv_branch}."
+          git clone --depth 1 ${sv_repo} -b ${sv_branch} suricata-verify
           if [[ "${sv_pr}" != "" ]]; then
+              echo "Switching to pull request ${sv_pr}."
               cd suricata-verify
               git fetch origin pull/${sv_pr}/head:prep
               git checkout prep


### PR DESCRIPTION
Add a comment to the pull request template on what to do if a custom
branch, repo or PR is required for Suricata-Update, Suricata-Verify or
libhtp.

Also accept the parsing of the value to accept values with no spaces
between the keyword and value.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [ ] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [ ] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
-
-
-

#suricata-verify-pr:
suricata-verify-repo: https://github.com/jasonish/suricata-verify
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
