### PR TITLE
dns: parse multiple txt segments into an array

### DIFF
--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -243,8 +243,8 @@ pub enum DNSRData {
     PTR(DNSName),
     MX(DNSName),
     NS(DNSName),
-    // RData is text
-    TXT(Vec<u8>),
+    // TXT records are an array of TXT entries
+    TXT(Vec<Vec<u8>>),
     NULL(Vec<u8>),
     // RData has several fields
     SOA(DNSRDataSOA),

--- a/rust/src/dns/lua.rs
+++ b/rust/src/dns/lua.rs
@@ -162,8 +162,19 @@ pub extern "C" fn SCDnsLuaGetAnswerTable(clua: &mut CLuaState, tx: &mut DNSTrans
                         lua.settable(-3);
                     }
                 }
-                DNSRData::TXT(ref bytes)
-                | DNSRData::NULL(ref bytes)
+                DNSRData::TXT(ref txt) => {
+                    if !txt.is_empty() {
+                        lua.pushstring("addr");
+                        let combined = txt
+                            .iter()
+                            .map(|s| String::from_utf8_lossy(s))
+                            .collect::<Vec<_>>()
+                            .join(" ");
+                        lua.pushstring(&combined);
+                        lua.settable(-3);
+                    }
+                }
+                DNSRData::NULL(ref bytes)
                 | DNSRData::Unknown(ref bytes) => {
                     if !bytes.is_empty() {
                         lua.pushstring("addr");


### PR DESCRIPTION
A DNS TXT answer record can actually be made of up multiple TXT entries in a single record. Suricata currently expands these into multiple TXT records, however that is not very representative of the actualy DNS message.

Instead, if a TXT record contains multiple labels, parse them into an array.

We still expand multiple TXT segements into multiple TXT records at logging time for compatibility, but this will allow something like MDNS to log more accurately to the protocol.

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [ ] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [ ] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [ ] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/

Describe changes:
-
-
-

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
