### PR TITLE
codecov/v3

### DIFF
--- a/examples/plugins/altemplate/Cargo.toml
+++ b/examples/plugins/altemplate/Cargo.toml
@@ -11,6 +11,7 @@ nom7 = { version="7.0", package="nom" }
 libc = "~0.2.82"
 suricata = { path = "../../../rust/" }
 suricata-sys = { path = "../../../rust/sys" }
+suricata-ffi = { path = "../../../rust/ffi" }
 
 [features]
 default = ["suricata8"]

--- a/examples/plugins/altemplate/src/plugin.rs
+++ b/examples/plugins/altemplate/src/plugin.rs
@@ -2,7 +2,7 @@ use super::template::template_register_parser;
 use crate::detect::detect_template_register;
 use crate::log::template_logger_log;
 use std::ffi::CString;
-use suricata::{SCLogError, SCLogNotice};
+use suricata_ffi::{SCLogError, SCLogNotice};
 use suricata_sys::sys::{
     SCAppLayerPlugin, SCOutputJsonLogDirection, SCPlugin, SCPluginRegisterAppLayer, SC_API_VERSION,
     SC_PACKAGE_VERSION,

--- a/examples/plugins/altemplate/src/template.rs
+++ b/examples/plugins/altemplate/src/template.rs
@@ -35,9 +35,8 @@ use suricata::applayer::{
 };
 use suricata::conf::conf_get;
 use suricata::core::{ALPROTO_UNKNOWN, IPPROTO_TCP};
-use suricata::{
-    build_slice, cast_pointer, export_state_data_get, export_tx_data_get, SCLogError, SCLogNotice,
-};
+use suricata::{build_slice, cast_pointer, export_state_data_get, export_tx_data_get};
+use suricata_ffi::{SCLogError, SCLogNotice};
 use suricata_sys::sys::{
     AppLayerParserState, AppProto, Flow, SCAppLayerParserConfParserEnabled,
     SCAppLayerParserRegisterLogger, SCAppLayerParserStateIssetFlag,

--- a/src/output-eve-bindgen.h
+++ b/src/output-eve-bindgen.h
@@ -56,6 +56,23 @@ typedef struct EveJsonTxLoggerRegistrationData {
 
 int SCOutputEvePreRegisterLogger(EveJsonTxLoggerRegistrationData reg_data);
 
+/** \brief Function type for EVE file-type initialization. */
+typedef int (*SCEveFileTypeInitFunc)(const SCConfNode *conf, const bool threaded, void **init_data);
+
+/** \brief Function type for EVE file-type thread initialization. */
+typedef int (*SCEveFileTypeThreadInitFunc)(
+        const void *init_data, const ThreadId thread_id, void **thread_data);
+
+/** \brief Function type for EVE file-type writes. */
+typedef int (*SCEveFileTypeWriteFunc)(
+        const char *buffer, const int buffer_len, const void *init_data, void *thread_data);
+
+/** \brief Function type for EVE file-type thread deinitialization. */
+typedef void (*SCEveFileTypeThreadDeinitFunc)(const void *init_data, void *thread_data);
+
+/** \brief Function type for EVE file-type deinitialization. */
+typedef void (*SCEveFileTypeDeinitFunc)(void *init_data);
+
 /** \brief Structure used to define an EVE output file type.
  *
  * EVE filetypes implement an object with a file-like interface and
@@ -120,7 +137,7 @@ typedef struct SCEveFileType_ {
      *
      * \retval 0 on success, -1 on failure
      */
-    int (*Init)(const SCConfNode *conf, const bool threaded, void **init_data);
+    SCEveFileTypeInitFunc Init;
 
     /**
      * \brief Initialize thread specific data.
@@ -141,7 +158,7 @@ typedef struct SCEveFileType_ {
      *
      * \retval 0 on success, -1 on failure
      */
-    int (*ThreadInit)(const void *init_data, const ThreadId thread_id, void **thread_data);
+    SCEveFileTypeThreadInitFunc ThreadInit;
 
     /**
      * \brief Called for each EVE log record.
@@ -160,8 +177,7 @@ typedef struct SCEveFileType_ {
      *
      * \retval 0 on success, -1 on failure
      */
-    int (*Write)(
-            const char *buffer, const int buffer_len, const void *init_data, void *thread_data);
+    SCEveFileTypeWriteFunc Write;
 
     /**
      * \brief Called to deinitialize each thread.
@@ -173,7 +189,7 @@ typedef struct SCEveFileType_ {
      *
      * \param thread_data The data setup in ThreadInit
      */
-    void (*ThreadDeinit)(const void *init_data, void *thread_data);
+    SCEveFileTypeThreadDeinitFunc ThreadDeinit;
 
     /**
      * \brief Final call to deinitialize this filetype.
@@ -183,7 +199,7 @@ typedef struct SCEveFileType_ {
      *
      * \param init_data Data setup in the call to Init.
      */
-    void (*Deinit)(void *init_data);
+    SCEveFileTypeDeinitFunc Deinit;
 
     /* Internal list management. */
     TAILQ_ENTRY(SCEveFileType_) entries;


### PR DESCRIPTION
- **examples/altemplate: use suricata-ffi for logging macros**
  

- **output-eve: bindgen SCEveFileType callback types**
  