### PR TITLE
rust/ffi: more rust friendly plugin registration

### DIFF
--- a/rust/ffi/src/plugin.rs
+++ b/rust/ffi/src/plugin.rs
@@ -17,10 +17,52 @@
 
 //! Plugin utility module.
 
-use suricata_sys::sys::SCLogGetLogLevel;
+use std::{ffi::CString, os::raw::c_char};
+use suricata_sys::sys::{SCLogGetLogLevel, SCPlugin, SC_API_VERSION, SC_PACKAGE_VERSION};
 
 pub fn init() {
     unsafe {
         crate::debug::set_log_level(SCLogGetLogLevel());
+    }
+}
+
+pub struct Plugin {
+    pub name: &'static str,
+
+    /// Plugin version.
+    pub version: &'static str,
+    pub license: &'static str,
+    pub author: &'static str,
+    pub init: unsafe extern "C" fn(),
+}
+
+impl Plugin {
+    /// Convert the plugin into a raw pointer suitable for plugin
+    /// registration.
+    pub fn into_raw(self) -> *mut SCPlugin {
+        let name = CString::new(self.name)
+            .expect("plugin name must not contain NUL bytes")
+            .into_raw() as *const c_char;
+        let plugin_version = CString::new(self.version)
+            .expect("plugin version must not contain NUL bytes")
+            .into_raw() as *const c_char;
+        let license = CString::new(self.license)
+            .expect("plugin license must not contain NUL bytes")
+            .into_raw() as *const c_char;
+        let author = CString::new(self.author)
+            .expect("plugin author must not contain NUL bytes")
+            .into_raw() as *const c_char;
+
+        let plugin = SCPlugin {
+            version: SC_API_VERSION,
+            suricata_version: SC_PACKAGE_VERSION.as_ptr() as *const c_char,
+            name,
+            plugin_version,
+            license,
+            author,
+            Init: Some(self.init),
+        };
+
+        Box::into_raw(Box::new(plugin))
     }
 }


### PR DESCRIPTION
A plugin can now create a "Plugin" struct with Rust strings.  The
`into_raw` method converts it to a raw pointer suitable for returning
during plugin registration.
