### PR TITLE
test/v2

### DIFF
--- a/doc/userguide/devguide/extending/flow-lifecycle-callbacks.rst
+++ b/doc/userguide/devguide/extending/flow-lifecycle-callbacks.rst
@@ -104,18 +104,19 @@ The Rust wrappers register closures or function items and return
 
 .. code-block:: rust
 
-   use suricata_ffi::flow::{self, Flow, Packet, ThreadVars};
+   use suricata_ffi::flow::{self, Flow, Packet};
+   use suricata_ffi::thread::ThreadVars;
    use suricata_ffi::SCLogNotice;
 
-   fn flow_init(_tv: *mut ThreadVars, f: *mut Flow, _p: *const Packet) {
+   fn flow_init(_tv: &mut ThreadVars, f: *mut Flow, _p: *const Packet) {
        SCLogNotice!("flow initialized: {:p}", f);
    }
 
-   fn flow_update(_tv: *mut ThreadVars, f: *mut Flow, p: *mut Packet) {
+   fn flow_update(_tv: &mut ThreadVars, f: *mut Flow, p: *mut Packet) {
        SCLogNotice!("flow updated: {:p} packet: {:p}", f, p);
    }
 
-   fn flow_finish(_tv: *mut ThreadVars, f: *mut Flow) {
+   fn flow_finish(_tv: &mut ThreadVars, f: *mut Flow) {
        SCLogNotice!("flow finished: {:p}", f);
    }
 

--- a/doc/userguide/devguide/extending/threads.rst
+++ b/doc/userguide/devguide/extending/threads.rst
@@ -38,3 +38,49 @@ registered. Registered callbacks are kept for the Suricata process lifetime.
 ``ThreadVars`` carries a lifetime tied to the callback invocation, so the
 borrow checker prevents it from being stored beyond the call. Rust callbacks
 must not panic, as they are invoked across an FFI boundary.
+
+Thread Storage
+==============
+
+``thread::ThreadStorage<T>`` provides typed, per-thread storage backed by
+Suricata's thread storage API. Each registered slot holds an independent value
+of type ``T`` for every thread.
+
+Register a slot once during initialization with
+``ThreadStorage::<T>::register``. Registration must happen before Suricata
+finalizes its storage registration, which is the case during plugin
+initialization.
+
+.. code-block:: rust
+
+   use suricata_ffi::thread::{self, ThreadStorage, ThreadVars};
+
+   #[derive(Default)]
+   struct ThreadState {
+       flows: u64,
+   }
+
+   fn register(storage: ThreadStorage<ThreadState>) -> Result<(), &'static str> {
+       thread::register_init_callback(move |tv| on_thread_init(storage, tv))
+   }
+
+Values are owned by Suricata's thread storage and are dropped automatically when
+the thread's storage is freed.
+
+Access the value for a thread through the ``ThreadVars`` wrapper. ``get`` takes
+``&ThreadVars`` and returns ``Option<&T>``. ``get_mut`` takes ``&mut
+ThreadVars`` and returns ``Option<&mut T>``. ``get_or_insert_with`` also takes
+``&mut ThreadVars`` and returns ``Result<&mut T, _>``, inserting a value
+produced by the closure if the slot is empty:
+
+.. code-block:: rust
+
+   fn on_thread_init(storage: ThreadStorage<ThreadState>, tv: &mut ThreadVars) {
+       let _ = storage.get_or_insert_with(tv, ThreadState::default);
+   }
+
+   fn on_flow_init(storage: ThreadStorage<ThreadState>, tv: &mut ThreadVars) {
+       if let Some(state) = storage.get_mut(tv) {
+           state.flows += 1;
+       }
+   }

--- a/doc/userguide/devguide/extending/threads.rst
+++ b/doc/userguide/devguide/extending/threads.rst
@@ -11,20 +11,19 @@ Thread Init Callback
 ====================
 
 Register a callback with ``thread::register_init_callback`` to run code for
-each Suricata thread as it is initialized. The callback receives a raw
-``ThreadVars`` pointer for the thread that has just been initialized.
+each Suricata thread as it is initialized. The callback receives a
+``ThreadVars`` wrapper for the thread that has just been initialized.
 
 The current Rust thread lifecycle API exposes an init callback only; there is
 no Rust thread deinit callback.
 
 .. code-block:: rust
 
-   use suricata_ffi::thread;
+   use suricata_ffi::thread::{self, ThreadVars};
    use suricata_ffi::SCLogNotice;
-   use suricata_sys::sys::ThreadVars;
 
-   fn on_thread_init(tv: *mut ThreadVars) {
-       SCLogNotice!("thread initialized: {:p}", tv);
+   fn on_thread_init(tv: &mut ThreadVars) {
+       SCLogNotice!("thread initialized: {:p}", tv.as_ptr());
    }
 
    fn register_thread_callbacks() -> Result<(), &'static str> {
@@ -32,9 +31,10 @@ no Rust thread deinit callback.
    }
 
 The wrapper accepts function items or closures that implement
-``Fn(*mut ThreadVars) + Send + Sync + 'static`` and returns
+``Fn(&mut ThreadVars) + Send + Sync + 'static`` and returns
 ``Result<(), &'static str>``. An error means the callback could not be
 registered. Registered callbacks are kept for the Suricata process lifetime.
 
-The ``ThreadVars`` pointer is only valid for the duration of the callback
-invocation and must not be stored. Rust callbacks must not panic.
+``ThreadVars`` carries a lifetime tied to the callback invocation, so the
+borrow checker prevents it from being stored beyond the call. Rust callbacks
+must not panic, as they are invoked across an FFI boundary.

--- a/examples/plugins/rust/src/mod.rs
+++ b/examples/plugins/rust/src/mod.rs
@@ -73,11 +73,11 @@ fn on_thread_init(tv: &mut ThreadVars) {
     );
 }
 
-fn log_flow_init(_tv: *mut sys::ThreadVars, _f: *mut Flow, _p: *const Packet) {
+fn log_flow_init(_tv: &mut ThreadVars, _f: *mut Flow, _p: *const Packet) {
     SCLogNotice!("rust example flow init callback: flow={:p}", _f);
 }
 
-fn log_flow_update(_tv: *mut sys::ThreadVars, _f: *mut Flow, _p: *mut Packet) {
+fn log_flow_update(_tv: &mut ThreadVars, _f: *mut Flow, _p: *mut Packet) {
     SCLogNotice!(
         "rust example flow update callback: flow={:p}, packet={:p}",
         _f,
@@ -85,7 +85,7 @@ fn log_flow_update(_tv: *mut sys::ThreadVars, _f: *mut Flow, _p: *mut Packet) {
     );
 }
 
-fn log_flow_finish(_tv: *mut sys::ThreadVars, _f: *mut Flow) {
+fn log_flow_finish(_tv: &mut ThreadVars, _f: *mut Flow) {
     SCLogNotice!("rust example flow finish callback: flow={:p}", _f);
 }
 

--- a/examples/plugins/rust/src/mod.rs
+++ b/examples/plugins/rust/src/mod.rs
@@ -3,21 +3,37 @@ use std::ptr::null_mut;
 use suricata_ffi::eve::{self, SCJsonBuilder};
 use suricata_ffi::flow;
 use suricata_ffi::jsonbuilder::JsonBuilder;
-use suricata_ffi::thread::{self, ThreadVars};
-use suricata_ffi::{SCLogError, SCLogNotice};
+use suricata_ffi::thread::{self, ThreadStorage, ThreadVars};
+use suricata_ffi::{SCLogError, SCLogNotice, SCLogWarning};
 use suricata_sys::sys::{self, Flow, Packet, SCEveRegisterCallback, SCPlugin};
+
+/// Per-thread state stored in Suricata thread storage.
+#[derive(Default)]
+struct ThreadState {
+    flows: u64,
+}
 
 unsafe extern "C" fn init() {
     suricata_ffi::plugin::init();
     SCLogNotice!("Initializing rust example plugin");
 
+    // Register per-thread storage once, then hand the (copyable) handle to the
+    // callbacks that use it.
+    let thread_storage = match ThreadStorage::<ThreadState>::register("rust-example-thread") {
+        Ok(storage) => storage,
+        Err(err) => {
+            SCLogError!("Failed to register rust example thread storage: {}", err);
+            return;
+        }
+    };
+
     if let Err(err) = register_eve_callbacks() {
         SCLogError!("Failed to register rust example EVE callbacks: {}", err);
     }
-    if let Err(err) = register_flow_callbacks() {
+    if let Err(err) = register_flow_callbacks(thread_storage) {
         SCLogError!("Failed to register rust example flow callbacks: {}", err);
     }
-    if let Err(err) = register_thread_callbacks() {
+    if let Err(err) = register_thread_callbacks(thread_storage) {
         SCLogError!("Failed to register rust example thread callbacks: {}", err);
     }
 }
@@ -29,15 +45,15 @@ fn register_eve_callbacks() -> Result<(), &'static str> {
     eve::register_callback(log_eve_wrapped)
 }
 
-fn register_flow_callbacks() -> Result<(), &'static str> {
-    flow::register_init_callback(log_flow_init)?;
+fn register_flow_callbacks(storage: ThreadStorage<ThreadState>) -> Result<(), &'static str> {
+    flow::register_init_callback(move |tv, f, p| log_flow_init(storage, tv, f, p))?;
     flow::register_update_callback(log_flow_update)?;
     flow::register_finish_callback(log_flow_finish)?;
     Ok(())
 }
 
-pub fn register_thread_callbacks() -> Result<(), &'static str> {
-    thread::register_init_callback(on_thread_init)
+fn register_thread_callbacks(storage: ThreadStorage<ThreadState>) -> Result<(), &'static str> {
+    thread::register_init_callback(move |tv| on_thread_init(storage, tv))
 }
 
 unsafe extern "C" fn log_eve_raw(
@@ -66,15 +82,39 @@ fn log_eve_wrapped(
     Ok(())
 }
 
-fn on_thread_init(tv: &mut ThreadVars) {
+fn on_thread_init(storage: ThreadStorage<ThreadState>, tv: &mut ThreadVars) {
+    // Initialize the per-thread storage for this thread.
+    if let Err(err) = storage.get_or_insert_with(tv, ThreadState::default) {
+        SCLogError!("failed to initialize rust example thread storage: {}", err);
+    }
     SCLogNotice!(
         "rust example thread init callback: thread={:p}",
         tv.as_ptr()
     );
 }
 
-fn log_flow_init(_tv: &mut ThreadVars, _f: *mut Flow, _p: *const Packet) {
-    SCLogNotice!("rust example flow init callback: flow={:p}", _f);
+fn log_flow_init(
+    storage: ThreadStorage<ThreadState>,
+    tv: &mut ThreadVars,
+    f: *mut Flow,
+    _p: *const Packet,
+) {
+    // Count flows seen by this thread using the per-thread storage.
+    let flows = match storage.get_mut(tv) {
+        Some(state) => {
+            state.flows += 1;
+            state.flows
+        }
+        None => {
+            SCLogWarning!("rust example thread storage was not initialized");
+            0
+        }
+    };
+    SCLogNotice!(
+        "rust example flow init callback: flow={:p}, thread_flows={}",
+        f,
+        flows
+    );
 }
 
 fn log_flow_update(_tv: &mut ThreadVars, _f: *mut Flow, _p: *mut Packet) {

--- a/examples/plugins/rust/src/mod.rs
+++ b/examples/plugins/rust/src/mod.rs
@@ -54,7 +54,7 @@ unsafe extern "C" fn log_eve_raw(
 }
 
 fn log_eve_wrapped(
-    _tv: *mut sys::ThreadVars,
+    _tv: &mut ThreadVars,
     _p: *const Packet,
     f: *mut Flow,
     jb: &mut JsonBuilder,

--- a/examples/plugins/rust/src/mod.rs
+++ b/examples/plugins/rust/src/mod.rs
@@ -3,9 +3,9 @@ use std::ptr::null_mut;
 use suricata_ffi::eve::{self, SCJsonBuilder};
 use suricata_ffi::flow;
 use suricata_ffi::jsonbuilder::JsonBuilder;
-use suricata_ffi::thread;
+use suricata_ffi::thread::{self, ThreadVars};
 use suricata_ffi::{SCLogError, SCLogNotice};
-use suricata_sys::sys::{Flow, Packet, SCEveRegisterCallback, SCPlugin, ThreadVars};
+use suricata_sys::sys::{self, Flow, Packet, SCEveRegisterCallback, SCPlugin};
 
 unsafe extern "C" fn init() {
     suricata_ffi::plugin::init();
@@ -41,7 +41,7 @@ pub fn register_thread_callbacks() -> Result<(), &'static str> {
 }
 
 unsafe extern "C" fn log_eve_raw(
-    _tv: *mut ThreadVars,
+    _tv: *mut sys::ThreadVars,
     _p: *const Packet,
     _f: *mut Flow,
     jb: *mut SCJsonBuilder,
@@ -54,7 +54,7 @@ unsafe extern "C" fn log_eve_raw(
 }
 
 fn log_eve_wrapped(
-    _tv: *mut ThreadVars,
+    _tv: *mut sys::ThreadVars,
     _p: *const Packet,
     f: *mut Flow,
     jb: &mut JsonBuilder,
@@ -66,15 +66,18 @@ fn log_eve_wrapped(
     Ok(())
 }
 
-fn on_thread_init(tv: *mut ThreadVars) {
-    SCLogNotice!("rust example thread init callback: thread={:p}", tv);
+fn on_thread_init(tv: &mut ThreadVars) {
+    SCLogNotice!(
+        "rust example thread init callback: thread={:p}",
+        tv.as_ptr()
+    );
 }
 
-fn log_flow_init(_tv: *mut ThreadVars, _f: *mut Flow, _p: *const Packet) {
+fn log_flow_init(_tv: *mut sys::ThreadVars, _f: *mut Flow, _p: *const Packet) {
     SCLogNotice!("rust example flow init callback: flow={:p}", _f);
 }
 
-fn log_flow_update(_tv: *mut ThreadVars, _f: *mut Flow, _p: *mut Packet) {
+fn log_flow_update(_tv: *mut sys::ThreadVars, _f: *mut Flow, _p: *mut Packet) {
     SCLogNotice!(
         "rust example flow update callback: flow={:p}, packet={:p}",
         _f,
@@ -82,7 +85,7 @@ fn log_flow_update(_tv: *mut ThreadVars, _f: *mut Flow, _p: *mut Packet) {
     );
 }
 
-fn log_flow_finish(_tv: *mut ThreadVars, _f: *mut Flow) {
+fn log_flow_finish(_tv: *mut sys::ThreadVars, _f: *mut Flow) {
     SCLogNotice!("rust example flow finish callback: flow={:p}", _f);
 }
 

--- a/rust/ffi/src/eve.rs
+++ b/rust/ffi/src/eve.rs
@@ -18,12 +18,14 @@
 use std::ffi::CString;
 use std::os::raw::c_void;
 
-pub use suricata_sys::sys::{Flow, Packet, SCEveUserCallbackFn, SCJsonBuilder, ThreadVars};
 use suricata_sys::sys::{
-    SCEveFileType, SCEveFileTypeDeinitFunc, SCEveFileTypeInitFunc, SCEveFileTypeThreadDeinitFunc,
-    SCEveFileTypeThreadInitFunc, SCEveFileTypeWriteFunc, SCEveRegisterCallback,
-    SCRegisterEveFileType,
+    self, SCEveFileType, SCEveFileTypeDeinitFunc, SCEveFileTypeInitFunc,
+    SCEveFileTypeThreadDeinitFunc, SCEveFileTypeThreadInitFunc, SCEveFileTypeWriteFunc,
+    SCEveRegisterCallback, SCRegisterEveFileType,
 };
+pub use suricata_sys::sys::{Flow, Packet, SCEveUserCallbackFn, SCJsonBuilder};
+
+use crate::thread::ThreadVars;
 
 pub struct EveFileType {
     pub name: &'static str,
@@ -111,7 +113,7 @@ impl EveFileType {
 pub fn register_callback<F>(callback: F) -> Result<(), &'static str>
 where
     F: Fn(
-            *mut ThreadVars,
+            &mut ThreadVars,
             *const Packet,
             *mut Flow,
             &mut crate::jsonbuilder::JsonBuilder,
@@ -134,10 +136,11 @@ where
 /// Internal wrapper used to adapt the C EVE callback to a Rust
 /// closure callback.
 unsafe extern "C" fn callback_wrapper<F>(
-    tv: *mut ThreadVars, p: *const Packet, f: *mut Flow, jb: *mut SCJsonBuilder, user: *mut c_void,
+    tv: *mut sys::ThreadVars, p: *const Packet, f: *mut Flow, jb: *mut SCJsonBuilder,
+    user: *mut c_void,
 ) where
     F: Fn(
-            *mut ThreadVars,
+            &mut ThreadVars,
             *const Packet,
             *mut Flow,
             &mut crate::jsonbuilder::JsonBuilder,
@@ -147,9 +150,10 @@ unsafe extern "C" fn callback_wrapper<F>(
         + 'static,
 {
     let callback = &*(user as *const F);
+    let mut tv = ThreadVars::from_ptr(tv);
     let mut jb = crate::jsonbuilder::JsonBuilder::from_raw(jb);
     let mark = jb.get_mark();
-    if callback(tv, p, f, &mut jb).is_err() {
+    if callback(&mut tv, p, f, &mut jb).is_err() {
         let _ = jb.restore_mark(&mark);
     }
 }

--- a/rust/ffi/src/flow.rs
+++ b/rust/ffi/src/flow.rs
@@ -17,10 +17,12 @@
 
 use std::os::raw::c_void;
 
-use suricata_sys::sys::{Flow, Packet, ThreadVars};
 use suricata_sys::sys::{
-    SCFlowRegisterFinishCallback, SCFlowRegisterInitCallback, SCFlowRegisterUpdateCallback,
+    self, Flow, Packet, SCFlowRegisterFinishCallback, SCFlowRegisterInitCallback,
+    SCFlowRegisterUpdateCallback,
 };
+
+use crate::thread::ThreadVars;
 
 /// Register a flow initialization callback.
 ///
@@ -37,7 +39,7 @@ use suricata_sys::sys::{
 /// The callback must not panic.
 pub fn register_init_callback<F>(callback: F) -> Result<(), &'static str>
 where
-    F: Fn(*mut ThreadVars, *mut Flow, *const Packet) + Send + Sync + 'static,
+    F: Fn(&mut ThreadVars, *mut Flow, *const Packet) + Send + Sync + 'static,
 {
     let user = Box::into_raw(Box::new(callback)) as *mut c_void;
     if unsafe { SCFlowRegisterInitCallback(Some(init_callback_wrapper::<F>), user) } {
@@ -66,7 +68,7 @@ where
 /// The callback must not panic.
 pub fn register_update_callback<F>(callback: F) -> Result<(), &'static str>
 where
-    F: Fn(*mut ThreadVars, *mut Flow, *mut Packet) + Send + Sync + 'static,
+    F: Fn(&mut ThreadVars, *mut Flow, *mut Packet) + Send + Sync + 'static,
 {
     let user = Box::into_raw(Box::new(callback)) as *mut c_void;
     if unsafe { SCFlowRegisterUpdateCallback(Some(update_callback_wrapper::<F>), user) } {
@@ -93,7 +95,7 @@ where
 /// The callback must not panic.
 pub fn register_finish_callback<F>(callback: F) -> Result<(), &'static str>
 where
-    F: Fn(*mut ThreadVars, *mut Flow) + Send + Sync + 'static,
+    F: Fn(&mut ThreadVars, *mut Flow) + Send + Sync + 'static,
 {
     let user = Box::into_raw(Box::new(callback)) as *mut c_void;
     if unsafe { SCFlowRegisterFinishCallback(Some(finish_callback_wrapper::<F>), user) } {
@@ -107,28 +109,31 @@ where
 }
 
 unsafe extern "C" fn init_callback_wrapper<F>(
-    tv: *mut ThreadVars, f: *mut Flow, p: *const Packet, user: *mut c_void,
+    tv: *mut sys::ThreadVars, f: *mut Flow, p: *const Packet, user: *mut c_void,
 ) where
-    F: Fn(*mut ThreadVars, *mut Flow, *const Packet) + Send + Sync + 'static,
+    F: Fn(&mut ThreadVars, *mut Flow, *const Packet) + Send + Sync + 'static,
 {
     let callback = &*(user as *const F);
-    callback(tv, f, p);
+    let mut tv = ThreadVars::from_ptr(tv);
+    callback(&mut tv, f, p);
 }
 
 unsafe extern "C" fn update_callback_wrapper<F>(
-    tv: *mut ThreadVars, f: *mut Flow, p: *mut Packet, user: *mut c_void,
+    tv: *mut sys::ThreadVars, f: *mut Flow, p: *mut Packet, user: *mut c_void,
 ) where
-    F: Fn(*mut ThreadVars, *mut Flow, *mut Packet) + Send + Sync + 'static,
+    F: Fn(&mut ThreadVars, *mut Flow, *mut Packet) + Send + Sync + 'static,
 {
     let callback = &*(user as *const F);
-    callback(tv, f, p);
+    let mut tv = ThreadVars::from_ptr(tv);
+    callback(&mut tv, f, p);
 }
 
 unsafe extern "C" fn finish_callback_wrapper<F>(
-    tv: *mut ThreadVars, f: *mut Flow, user: *mut c_void,
+    tv: *mut sys::ThreadVars, f: *mut Flow, user: *mut c_void,
 ) where
-    F: Fn(*mut ThreadVars, *mut Flow) + Send + Sync + 'static,
+    F: Fn(&mut ThreadVars, *mut Flow) + Send + Sync + 'static,
 {
     let callback = &*(user as *const F);
-    callback(tv, f);
+    let mut tv = ThreadVars::from_ptr(tv);
+    callback(&mut tv, f);
 }

--- a/rust/ffi/src/thread.rs
+++ b/rust/ffi/src/thread.rs
@@ -15,9 +15,37 @@
  * 02110-1301, USA.
  */
 
+use std::marker::PhantomData;
 use std::os::raw::c_void;
 
-use suricata_sys::sys::{SCThreadRegisterInitCallback, ThreadVars};
+use suricata_sys::sys::{self, SCThreadRegisterInitCallback};
+
+/// A safe wrapper around a Suricata `sys::ThreadVars` pointer.
+///
+/// A wrapper around `sys::ThreadVars` that carries a lifetime.
+pub struct ThreadVars<'a> {
+    tv: *mut sys::ThreadVars,
+    _marker: PhantomData<&'a mut sys::ThreadVars>,
+}
+
+impl<'a> ThreadVars<'a> {
+    /// Wrap a raw `ThreadVars` pointer.
+    ///
+    /// # Safety
+    ///
+    /// `tv` must be a valid `ThreadVars` pointer provided by Suricata.
+    pub unsafe fn from_ptr(tv: *mut sys::ThreadVars) -> Self {
+        Self {
+            tv,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Return the underlying raw `ThreadVars` pointer for read-only access.
+    pub fn as_ptr(&self) -> *const sys::ThreadVars {
+        self.tv
+    }
+}
 
 /// Register a thread initialization callback.
 ///
@@ -33,7 +61,7 @@ use suricata_sys::sys::{SCThreadRegisterInitCallback, ThreadVars};
 /// The callback must not panic.
 pub fn register_init_callback<F>(callback: F) -> Result<(), &'static str>
 where
-    F: Fn(*mut ThreadVars) + Send + Sync + 'static,
+    F: Fn(*mut sys::ThreadVars) + Send + Sync + 'static,
 {
     let user = Box::into_raw(Box::new(callback)) as *mut c_void;
     if unsafe { SCThreadRegisterInitCallback(Some(init_callback_wrapper::<F>), user) } {
@@ -46,9 +74,9 @@ where
     }
 }
 
-unsafe extern "C" fn init_callback_wrapper<F>(tv: *mut ThreadVars, user: *mut c_void)
+unsafe extern "C" fn init_callback_wrapper<F>(tv: *mut sys::ThreadVars, user: *mut c_void)
 where
-    F: Fn(*mut ThreadVars) + Send + Sync + 'static,
+    F: Fn(*mut sys::ThreadVars) + Send + Sync + 'static,
 {
     let callback = &*(user as *const F);
     callback(tv);

--- a/rust/ffi/src/thread.rs
+++ b/rust/ffi/src/thread.rs
@@ -15,10 +15,14 @@
  * 02110-1301, USA.
  */
 
+use std::ffi::CString;
 use std::marker::PhantomData;
 use std::os::raw::c_void;
 
-use suricata_sys::sys::{self, SCThreadRegisterInitCallback};
+use suricata_sys::sys::{
+    self, SCThreadGetStorageById, SCThreadRegisterInitCallback, SCThreadSetStorageById,
+    SCThreadStorageId, SCThreadStorageRegister,
+};
 
 /// A safe wrapper around a Suricata `sys::ThreadVars` pointer.
 ///
@@ -44,6 +48,129 @@ impl<'a> ThreadVars<'a> {
     /// Return the underlying raw `ThreadVars` pointer for read-only access.
     pub fn as_ptr(&self) -> *const sys::ThreadVars {
         self.tv
+    }
+
+    /// Return the underlying raw `ThreadVars` pointer for mutable access.
+    ///
+    /// Requires `&mut self` so that mutable use of the underlying
+    /// `ThreadVars` (such as setting thread storage) is gated by an exclusive
+    /// borrow of the wrapper.
+    fn as_mut_ptr(&mut self) -> *mut sys::ThreadVars {
+        self.tv
+    }
+}
+
+/// A typed handle to a per-thread storage slot.
+///
+/// `ThreadStorage<T>` wraps the `SCThreadStorageId` returned when registering
+/// thread storage with Suricata. Values are stored as a `Box<T>` owned by
+/// Suricata's thread storage and are dropped automatically when the thread's
+/// storage is freed.
+///
+/// The handle only holds the storage id, so it is `Copy` and `Send`/`Sync`
+/// regardless of `T`, and can be passed by value into the callbacks that need
+/// it.
+pub struct ThreadStorage<T> {
+    id: SCThreadStorageId,
+    _marker: PhantomData<fn() -> T>,
+}
+
+// Manual `Copy`/`Clone` impls so the handle is copyable regardless of whether
+// `T` is; it only holds the storage id.
+impl<T> Clone for ThreadStorage<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T> Copy for ThreadStorage<T> {}
+
+impl<T: Send + 'static> ThreadStorage<T> {
+    /// Register a new thread storage slot for values of type `T`.
+    ///
+    /// `name` must be unique among registered thread storage. Registration has
+    /// to happen during initialization, before Suricata finalizes storage
+    /// registration (`SCStorageFinalize`).
+    ///
+    /// Returns an error if `name` contains an interior nul byte or if Suricata
+    /// rejects the registration.
+    pub fn register(name: &str) -> Result<Self, &'static str> {
+        let name = CString::new(name).map_err(|_| "thread storage name contains a nul byte")?;
+        let id = unsafe { SCThreadStorageRegister(name.as_ptr(), Some(Self::free)) };
+        if id.id < 0 {
+            return Err("Failed to register thread storage");
+        }
+
+        // Suricata keeps the storage name pointer in its storage mapping for
+        // the lifetime of the process, so the CString is intentionally leaked.
+        std::mem::forget(name);
+
+        Ok(Self {
+            id,
+            _marker: PhantomData,
+        })
+    }
+
+    /// Return a reference to the value stored for `tv`, if any.
+    pub fn get<'t>(&self, tv: &'t ThreadVars<'_>) -> Option<&'t T> {
+        let ptr = unsafe { SCThreadGetStorageById(tv.as_ptr(), self.id) };
+        if ptr.is_null() {
+            None
+        } else {
+            Some(unsafe { &*(ptr as *const T) })
+        }
+    }
+
+    /// Return a mutable reference to the value stored for `tv`, if any.
+    ///
+    /// Takes `&mut ThreadVars` so the returned `&mut T` is the only live
+    /// reference to the stored value for the duration of the borrow.
+    pub fn get_mut<'t>(&self, tv: &'t mut ThreadVars<'_>) -> Option<&'t mut T> {
+        let ptr = unsafe { SCThreadGetStorageById(tv.as_ptr(), self.id) };
+        if ptr.is_null() {
+            None
+        } else {
+            Some(unsafe { &mut *(ptr as *mut T) })
+        }
+    }
+
+    /// Return a mutable reference to the value stored for `tv`, inserting the
+    /// value produced by `init` if none is present yet.
+    ///
+    /// Takes `&mut ThreadVars` so the returned `&mut T` is the only live
+    /// reference to the stored value for the duration of the borrow.
+    pub fn get_or_insert_with<'t>(
+        &self, tv: &'t mut ThreadVars<'_>, init: impl FnOnce() -> T,
+    ) -> Result<&'t mut T, &'static str> {
+        let ptr = unsafe { SCThreadGetStorageById(tv.as_ptr(), self.id) };
+        if !ptr.is_null() {
+            return Ok(unsafe { &mut *(ptr as *mut T) });
+        }
+
+        // `SCThreadSetStorageById` overwrites the slot without freeing any
+        // previous value; we only reach here when the slot is empty.
+        let ptr = Box::into_raw(Box::new(init()));
+        let rc = unsafe { SCThreadSetStorageById(tv.as_mut_ptr(), self.id, ptr.cast()) };
+        if rc != 0 {
+            unsafe {
+                drop(Box::from_raw(ptr));
+            }
+            return Err("Failed to set thread storage");
+        }
+
+        Ok(unsafe { &mut *ptr })
+    }
+
+    /// Free callback registered with Suricata thread storage that drops the
+    /// `Box<T>` backing a stored value.
+    unsafe extern "C" fn free(ptr: *mut c_void) {
+        if !ptr.is_null() {
+            // The drop runs across an FFI boundary, so guard against unwinding
+            // into C if `T`'s `Drop` panics.
+            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                drop(Box::from_raw(ptr as *mut T));
+            }));
+        }
     }
 }
 

--- a/rust/ffi/src/thread.rs
+++ b/rust/ffi/src/thread.rs
@@ -52,16 +52,9 @@ impl<'a> ThreadVars<'a> {
 /// The callback is invoked for every thread being initialized during Suricata
 /// startup. It receives the `ThreadVars` for the thread that has just been
 /// initialized.
-///
-/// # Safety
-///
-/// The callback receives a raw pointer from Suricata. This pointer is only
-/// valid for the duration of the callback invocation and must not be stored.
-///
-/// The callback must not panic.
 pub fn register_init_callback<F>(callback: F) -> Result<(), &'static str>
 where
-    F: Fn(*mut sys::ThreadVars) + Send + Sync + 'static,
+    F: Fn(&mut ThreadVars) + Send + Sync + 'static,
 {
     let user = Box::into_raw(Box::new(callback)) as *mut c_void;
     if unsafe { SCThreadRegisterInitCallback(Some(init_callback_wrapper::<F>), user) } {
@@ -76,8 +69,9 @@ where
 
 unsafe extern "C" fn init_callback_wrapper<F>(tv: *mut sys::ThreadVars, user: *mut c_void)
 where
-    F: Fn(*mut sys::ThreadVars) + Send + Sync + 'static,
+    F: Fn(&mut ThreadVars) + Send + Sync + 'static,
 {
     let callback = &*(user as *const F);
-    callback(tv);
+    let mut tv = ThreadVars::from_ptr(tv);
+    callback(&mut tv);
 }

--- a/rust/sys/src/sys.rs
+++ b/rust/sys/src/sys.rs
@@ -1862,6 +1862,39 @@ extern "C" {
     #[doc = " \\internal\n\n Run all registered flow init callbacks."]
     pub fn SCThreadRunInitCallbacks(tv: *mut ThreadVars);
 }
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+pub struct SCThreadStorageId {
+    pub id: ::std::os::raw::c_int,
+}
+extern "C" {
+    pub fn SCThreadStorageSize() -> ::std::os::raw::c_uint;
+}
+extern "C" {
+    pub fn SCThreadGetStorageById(
+        tv: *const ThreadVars, id: SCThreadStorageId,
+    ) -> *mut ::std::os::raw::c_void;
+}
+extern "C" {
+    pub fn SCThreadSetStorageById(
+        tv: *mut ThreadVars, id: SCThreadStorageId, ptr: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn SCThreadFreeStorageById(tv: *mut ThreadVars, id: SCThreadStorageId);
+}
+extern "C" {
+    pub fn SCThreadFreeStorage(tv: *mut ThreadVars);
+}
+extern "C" {
+    pub fn SCRegisterThreadStorageTests();
+}
+extern "C" {
+    pub fn SCThreadStorageRegister(
+        name: *const ::std::os::raw::c_char,
+        Free: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
+    ) -> SCThreadStorageId;
+}
 extern "C" {
     pub fn SCSRepCatGetByShortname(shortname: *const ::std::os::raw::c_char) -> u8;
 }

--- a/src/bindgen.h
+++ b/src/bindgen.h
@@ -65,6 +65,7 @@
 #include "flow-callbacks.h"
 
 #include "thread-callbacks.h"
+#include "thread-storage.h"
 
 #include "reputation.h"
 #include "feature.h"

--- a/src/thread-storage.h
+++ b/src/thread-storage.h
@@ -22,7 +22,9 @@
 #ifndef SURICATA_THREAD_STORAGE_H
 #define SURICATA_THREAD_STORAGE_H
 
+#ifndef SURICATA_BINDGEN_H
 #include "threadvars.h"
+#endif
 
 typedef struct SCThreadStorageId {
     int id;


### PR DESCRIPTION
- **rust/ffi: add wrapper around ThreadVars**
  A Rust wrapper around ThreadVars to enforce Rust lifetimes to ThreadVars when
  used in a callback.
  
  Ticket: #8598
  

- **rust/ffi: use ThreadVars wrapper in thread init callback**
  Update the thread init callback registration to pass the safe ThreadVars
  wrapper instead of a raw pointer.
  
  Ticket: #8598
  

- **rust/ffi: use ThreadVars wrapper in eve callback**
  Update the EVE callback registration to pass the safe ThreadVars wrapper
  instead of a raw pointer.
  
  Ticket: #8598
  

- **rust/ffi: use ThreadVars wrapper in flow callbacks**
  Update the flow init, update and finish callback registrations to pass the
  safe ThreadVars wrapper instead of a raw pointer.
  
  Ticket: #8598
  

- **rust/ffi: bindgen thread storage**
  Ticket: #8445
  

- **rust/ffi: add safe thread storage wrapper**
  Add a typed ThreadStorage<T> wrapper around the thread storage bindings.
  
  Ticket: #8445
  

- **github-ci: close PRs updated after being opened**
  Enforce our policy of requiring a new pull request whenever changes are
  made to an existing one. On any push to an open, non-draft pull request
  the workflow comments with the policy and closes the pull request.
  

- **fixup**
  

- **bar**
  

- **fixup**
  